### PR TITLE
fixing the spi port for the edison board

### DIFF
--- a/apa102/src/main/java/com/example/androidthings/driversamples/BoardDefaults.java
+++ b/apa102/src/main/java/com/example/androidthings/driversamples/BoardDefaults.java
@@ -33,7 +33,7 @@ public class BoardDefaults {
         switch (Build.DEVICE) {
             // same for Edison Arduino breakout and Edison SOM
             case DEVICE_EDISON:
-                return "SPI2";
+                return "SPI2.1";
             case DEVICE_JOULE:
                 return "SPI0.0";
             case DEVICE_RPI3:


### PR DESCRIPTION
This fixes the BoardDefaults for the apa-102 example to use the correct one for the Edison board.